### PR TITLE
W-23365932: Add Australia Cloud to Anypoint MQ docs

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -213,7 +213,7 @@ Billing is based on the number of messages delivered to subscribers from queues,
 |===
 |Anypoint MQ Feature 
 |US Cloud and EU Cloud
-|Canada Cloud, Japan Cloud, India Cloud
+|Canada Cloud, Japan Cloud, India Cloud, Australia Cloud
 |MuleSoft Government Cloud
 
 |{empty}
@@ -266,13 +266,13 @@ Billing is based on the number of messages delivered to subscribers from queues,
 [[mq-on-hyperforce]]
 === Limitations by Control Plane
 
-All Anypoint MQ features are supported on https://gov.anypoint.mulesoft.com/login/[MuleSoft Government Cloud], https://ca1.platform.mulesoft.com[Canada Cloud], https://jp1.platform.mulesoft.com[Japan Cloud], and https://in1.platform.mulesoft.com[India Cloud] with the following exceptions:
+All Anypoint MQ features are supported on https://gov.anypoint.mulesoft.com/login/[MuleSoft Government Cloud], https://ca1.platform.mulesoft.com[Canada Cloud], https://jp1.platform.mulesoft.com[Japan Cloud], https://in1.platform.mulesoft.com[India Cloud], and https://au1.platform.mulesoft.com[Australia Cloud] with the following exceptions:
 
 [%header,cols="2a,1a,1a"]
 |===
 | Limitation
 | MuleSoft Government Cloud
-| Canada Cloud, Japan Cloud, India Cloud
+| Canada Cloud, Japan Cloud, India Cloud, Australia Cloud
 
 | *xref:mq-queues.adoc[Unencrypted Queues]*
 | Not supported. When xref:mq-queues.adoc#create-a-queue[creating a queue], *Encryption* defaults to selected.

--- a/modules/ROOT/pages/mq-faq.adoc
+++ b/modules/ROOT/pages/mq-faq.adoc
@@ -53,6 +53,9 @@ Anypoint MQ standard and FIFO queues are available in these regions:
 
 | https://in1.platform.mulesoft.com[India Cloud]
 | Asia Pacific | India (Mumbai) | `ap-south-1` <<mq-hyperforce,^***^>>
+
+| https://au1.platform.mulesoft.com[Australia Cloud]
+| Asia Pacific | Australia (Sydney) | `ap-southeast-2` <<mq-hyperforce,^***^>>
 |===
 
 [[mq-hyperforce]]


### PR DESCRIPTION
## Summary

Replicates India Cloud changes from PR #208 for Australia Cloud (`au1.platform.mulesoft.com`).

- **`index.adoc`**: Updated feature comparison table column header to include Australia Cloud. Updated Limitations section intro sentence and table column header to include Australia Cloud.
- **`mq-faq.adoc`**: Added Australia Cloud row (`ap-southeast-2`, Asia Pacific, Australia (Sydney)) to the MQ regions table.