### PR TITLE
W-23748914: Add United Kingdom Cloud to Anypoint MQ docs

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -213,7 +213,7 @@ Billing is based on the number of messages delivered to subscribers from queues,
 |===
 |Anypoint MQ Feature 
 |US Cloud and EU Cloud
-|Canada Cloud, Japan Cloud, India Cloud, Australia Cloud
+|Canada Cloud, Japan Cloud, India Cloud, Australia Cloud, United Kingdom Cloud
 |MuleSoft Government Cloud
 
 |{empty}
@@ -266,13 +266,13 @@ Billing is based on the number of messages delivered to subscribers from queues,
 [[mq-on-hyperforce]]
 === Limitations by Control Plane
 
-All Anypoint MQ features are supported on https://gov.anypoint.mulesoft.com/login/[MuleSoft Government Cloud], https://ca1.platform.mulesoft.com[Canada Cloud], https://jp1.platform.mulesoft.com[Japan Cloud], https://in1.platform.mulesoft.com[India Cloud], and https://au1.platform.mulesoft.com[Australia Cloud] with the following exceptions:
+All Anypoint MQ features are supported on https://gov.anypoint.mulesoft.com/login/[MuleSoft Government Cloud], https://ca1.platform.mulesoft.com[Canada Cloud], https://jp1.platform.mulesoft.com[Japan Cloud], https://in1.platform.mulesoft.com[India Cloud], https://au1.platform.mulesoft.com[Australia Cloud], and https://gb1.platform.mulesoft.com[United Kingdom Cloud] with the following exceptions:
 
 [%header,cols="2a,1a,1a"]
 |===
 | Limitation
 | MuleSoft Government Cloud
-| Canada Cloud, Japan Cloud, India Cloud, Australia Cloud
+| Canada Cloud, Japan Cloud, India Cloud, Australia Cloud, United Kingdom Cloud
 
 | *xref:mq-queues.adoc[Unencrypted Queues]*
 | Not supported. When xref:mq-queues.adoc#create-a-queue[creating a queue], *Encryption* defaults to selected.

--- a/modules/ROOT/pages/mq-faq.adoc
+++ b/modules/ROOT/pages/mq-faq.adoc
@@ -56,6 +56,9 @@ Anypoint MQ standard and FIFO queues are available in these regions:
 
 | https://au1.platform.mulesoft.com[Australia Cloud]
 | Asia Pacific | Australia (Sydney) | `ap-southeast-2` <<mq-hyperforce,^***^>>
+
+| https://gb1.platform.mulesoft.com[United Kingdom Cloud]
+| Europe | United Kingdom (London) | `eu-west-2` <<mq-hyperforce,^***^>>
 |===
 
 [[mq-hyperforce]]


### PR DESCRIPTION
## Summary

Replicates the Australia Cloud changes from PR #213 for United Kingdom Cloud (`gb1.platform.mulesoft.com`).

- **`index.adoc`**: Updated the feature comparison and Limitations table column headers and the Limitations intro sentence to include United Kingdom Cloud.
- **`mq-faq.adoc`**: Added United Kingdom Cloud row (`eu-west-2`, Europe, United Kingdom (London)) to the MQ regions table.

Made with [Cursor](https://cursor.com)